### PR TITLE
feat: add a check for 'Reset account lockout counter after'

### DIFF
--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -228,7 +228,7 @@ groups:
           test_items:
             - flag: ""
               compare:
-                op: lte
+                op: gte
                 value: 15
               set: true
         remediation: >

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -215,3 +215,23 @@ groups:
           To establish the recommended configuration via GP, set the following UI path to 5 or fewer invalid login attempt(s), but not 0:
               Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Account Lockout Policy\Account lockout threshold
         scored: true
+      - id: 1.2.4
+        description: Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' (Automated)
+        audittype: powershell
+        audit:
+          cmd:
+            DomainController: Get-ADDefaultDomainPasswordPolicy -Current LocalComputer |
+              Select -ExpandProperty LockoutThreshold
+            Server: Get-ADDefaultDomainPasswordPolicy -Current LocalComputer |
+              Select -ExpandProperty LockoutThreshold
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: lte
+                value: 15
+              set: true
+        remediation: >
+          To establish the recommended configuration via GP, set the following UI path to 15 or more minute(s):
+              Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Account Lockout Policy\Reset account lockout counter after
+        scored: true

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -221,9 +221,9 @@ groups:
         audit:
           cmd:
             DomainController: Get-ADDefaultDomainPasswordPolicy -Current LocalComputer |
-              Select -ExpandProperty LockoutThreshold
+              Select -ExpandProperty LockoutObservationWindow | Select -ExpandProperty Minutes
             Server: Get-ADDefaultDomainPasswordPolicy -Current LocalComputer |
-              Select -ExpandProperty LockoutThreshold
+              Select -ExpandProperty LockoutObservationWindow | Select -ExpandProperty Minutes
         tests:
           test_items:
             - flag: ""


### PR DESCRIPTION
Add a check for [Reset account lockout counter after](https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/reset-account-lockout-counter-after), that determines the length of time before the Account lockout threshold resets to zero.

