### PR TITLE
feat: add a manual policy for 'Allow Administrator account lockout'

### DIFF
--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -215,6 +215,14 @@ groups:
           To establish the recommended configuration via GP, set the following UI path to 5 or fewer invalid login attempt(s), but not 0:
               Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Account Lockout Policy\Account lockout threshold
         scored: true
+      - id: 1.2.3
+        description: Ensure 'Allow Administrator account lockout' is set to 'Enabled' (Manual)
+        type: manual
+        remediation: >
+          To establish the recommended configuration via GP, set the following UI path to 15 or more minute(s):
+              Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Account Lockout Policies\Allow Administrator account lockout
+        scored: true
+
       - id: 1.2.4
         description: Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)' (Automated)
         audittype: powershell


### PR DESCRIPTION
This PR adds a manual policy to ensure 'Allow Administrator account lockout' is set to 'Enabled'.

**Note:** Tests of type manual won't be run and will be marked as Warn:
https://github.com/aquasecurity/bench-common/blob/b6528bb7bd9c4bfe8b9fb684663d1660f7e34401/check/check.go#L126C2-L126C2

![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/c930360e-dbf7-4dcc-9d61-97acb1fba220)
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/b1757e9b-6e8d-4e86-b8bf-decf9555df04)
