### PR TITLE
feat: add a check for 'Access Credential Manager as a trusted caller'

### DIFF
--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -241,6 +241,14 @@ groups:
       - id: 2.2.1
         description: Ensure 'Access Credential Manager as a trusted caller' is set to 'No One' (Automated
         audittype: powershell
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+
         remediation: >
           To establish the recommended configuration via GP, set the following UI path to "No One":
              Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Local Policies\User Rights Assignment\Access Credential Manager as a trusted caller

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -239,7 +239,7 @@ groups:
     description: User Rights Assignment
     checks:
       - id: 2.2.1
-        description: Ensure 'Access Credential Manager as a trusted caller' is set to 'No One' (Automated
+        description: Ensure 'Access Credential Manager as a trusted caller' is set to 'No One' (Automated)
         audittype: powershell
         audit:
           cmd:

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -235,3 +235,13 @@ groups:
           To establish the recommended configuration via GP, set the following UI path to 15 or more minute(s):
               Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Account Lockout Policy\Reset account lockout counter after
         scored: true
+  - id: 2.2
+    description: User Rights Assignment
+    checks:
+      - id: 2.2.1
+        description: Ensure 'Access Credential Manager as a trusted caller' is set to 'No One' (Automated
+        audittype: powershell
+        remediation: >
+          To establish the recommended configuration via GP, set the following UI path to "No One":
+             Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Local Policies\User Rights Assignment\Access Credential Manager as a trusted caller
+        scored: true

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -241,6 +241,10 @@ groups:
       - id: 2.2.1
         description: Ensure 'Access Credential Manager as a trusted caller' is set to 'No One' (Automated
         audittype: powershell
+        audit:
+          cmd:
+            DomainController: SecEdit /export /cfg seccfg /areas USER_RIGHTS > $null; Get-Content seccfg | Select-String -Pattern "SeTrustedCredManAccessPrivilege" ; Remove-Item seccfg
+            Server: SecEdit /export /cfg seccfg /areas USER_RIGHTS > $null; Get-Content seccfg | Select-String -Pattern "SeTrustedCredManAccessPrivilege" ; Remove-Item seccfg
         tests:
           test_items:
             - flag: ""

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -243,8 +243,8 @@ groups:
         audittype: powershell
         audit:
           cmd:
-            DomainController: SecEdit /export /cfg seccfg /areas USER_RIGHTS > $null; Get-Content seccfg | Select-String -Pattern "SeTrustedCredManAccessPrivilege" ; Remove-Item seccfg
-            Server: SecEdit /export /cfg seccfg /areas USER_RIGHTS > $null; Get-Content seccfg | Select-String -Pattern "SeTrustedCredManAccessPrivilege" ; Remove-Item seccfg
+            DomainController: SecEdit /export /cfg seccfg /areas USER_RIGHTS /quiet ; Get-Content seccfg | Select-String -Pattern "SeTrustedCredManAccessPrivilege" ; Remove-Item seccfg
+            Server: SecEdit /export /cfg seccfg /areas USER_RIGHTS /quiet ; Get-Content seccfg | Select-String -Pattern "SeTrustedCredManAccessPrivilege" ; Remove-Item seccfg
         tests:
           test_items:
             - flag: ""


### PR DESCRIPTION
This PR adds a policy  to ensure `Access Credential Manager as a trusted caller` isn't set.

when there is an account with the credential:
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/c9f178f3-0c0b-43f4-a329-0fe9662ba77e)

without:
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/ff893efa-2443-4692-9115-fe1bfe6a6496)
