### PR TITLE
chore: ignore GoLand's files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ bin
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 .vscode
+.idea
 coverage.txt
 dist/


### PR DESCRIPTION
This PR adds skipping `idea` folder that contains Goland's files.