### PR TITLE
feat: add a check 'Access this computer from the network' for Domain Controller

### DIFF
--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -265,3 +265,10 @@ groups:
           To establish the recommended configuration via GP, set the following UI path to "No One":
              Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Local Policies\User Rights Assignment\Access Credential Manager as a trusted caller
         scored: true
+      - id: 2.2.2
+        description: Ensure 'Access this computer from the network' is set to 'Administrators, Authenticated Users, ENTERPRISE DOMAIN CONTROLLERS' (DC only) (Automated)
+        audittype: powershell
+        remediation: >
+          To establish the recommended configuration via GP, configure the following UI path:
+             Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Access this computer from the network
+        scored: true

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -268,6 +268,9 @@ groups:
       - id: 2.2.2
         description: Ensure 'Access this computer from the network' is set to 'Administrators, Authenticated Users, ENTERPRISE DOMAIN CONTROLLERS' (DC only) (Automated)
         audittype: powershell
+        audit:
+          cmd:
+            DomainController: SecEdit /export /cfg seccfg /areas USER_RIGHTS /quiet ; Get-Content seccfg | Select-String -Pattern "SeNetworkLogonRight" ; Remove-Item seccfg
         remediation: >
           To establish the recommended configuration via GP, configure the following UI path:
              Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Access this computer from the network

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -270,7 +270,7 @@ groups:
         audittype: powershell
         audit:
           cmd:
-            DomainController: SecEdit /export /cfg seccfg /areas USER_RIGHTS /quiet ; Get-Content seccfg | Select-String -Pattern "SeNetworkLogonRight" ; Remove-Item seccfg
+            DomainController: SecEdit /export /cfg seccfg /areas USER_RIGHTS /quiet ; (Get-Content seccfg | Select-String -Pattern "SeNetworkLogonRight") -replace '^.*= |[*]' ; Remove-Item seccfg
         tests:
           test_items:
             - flag: ""

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -271,6 +271,13 @@ groups:
         audit:
           cmd:
             DomainController: SecEdit /export /cfg seccfg /areas USER_RIGHTS /quiet ; Get-Content seccfg | Select-String -Pattern "SeNetworkLogonRight" ; Remove-Item seccfg
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: valid_elements
+                value: "S-1-5-32-544,S-1-5-11,S-1-5-9"
+              set: true
         remediation: >
           To establish the recommended configuration via GP, configure the following UI path:
              Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Access this computer from the network


### PR DESCRIPTION
This policy checks 'Access this computer from the network' for Domain Controller.
The recommended state for this setting is: Administrators, Authenticated Users, ENTERPRISE DOMAIN CONTROLLERS.
Their SIDs are next:
* S-1-5-32-544 (Administrators)
* S-1-5-11 (Authenticated Users)
* S-1-5-9 (Enterprise Domain Controllers)

Read more here: [Well-known SIDs](https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers#well-known-sids).

the reuslt for Administrators, Authenticated Users, Enterprise Domain Controllers:
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/338b09ef-b74b-43ef-bfec-6b1cd1bcbff2)

the reuslt for Administrators, Authenticated Users, Enterprise Domain Controllers, Everyone:
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/fd1ea72d-5d6f-49d7-b4bb-a99c0742d291)
