### PR TITLE
fix: update UI path for 'Access Credential Manager as a trusted caller'

### DIFF
--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -263,5 +263,5 @@ groups:
 
         remediation: >
           To establish the recommended configuration via GP, set the following UI path to "No One":
-             Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Local Policies\User Rights Assignment\Access Credential Manager as a trusted caller
+             Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Access Credential Manager as a trusted caller
         scored: true


### PR DESCRIPTION
There is a mistake in UI path for 'Access Credential Manager as a trusted caller'