### PR TITLE
feat: add a check 'Act as part of the operating system'

### DIFF
--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -265,3 +265,21 @@ groups:
           To establish the recommended configuration via GP, set the following UI path to "No One":
              Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Local Policies\User Rights Assignment\Access Credential Manager as a trusted caller
         scored: true
+      - id: 2.2.4
+        description: Ensure 'Act as part of the operating system' is set to 'No One' (Automated)
+        audittype: powershell
+        audit:
+          cmd:
+            DomainController: SecEdit /export /cfg seccfg /areas USER_RIGHTS /quiet ; Get-Content seccfg | Select-String -Pattern "SeTcbPrivilege" ; Remove-Item seccfg
+            Server: SecEdit /export /cfg seccfg /areas USER_RIGHTS /quiet ; Get-Content seccfg | Select-String -Pattern "SeTcbPrivilege" ; Remove-Item seccfg
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: ""
+              set: true
+        remediation: >
+          To establish the recommended configuration via GP, set the following UI path to "No One":
+             Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Act as part of the operating system
+        scored: true


### PR DESCRIPTION
This policy checks that 'Act as part of the operating system' has no values.

The result without any users (by default):
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/6e4da147-2dbf-412b-8466-5810779ebb79)

The result with any users:
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/0e1cf6cb-5476-494b-ae46-68c93a93f3e3)
