### PR TITLE
feat: add checks for 2.3 Security Options

### DIFF
--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -300,3 +300,26 @@ groups:
           To establish the recommended configuration via GP, configure the following UI path:
              Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Access this computer from the network
         scored: true
+
+  - id: 2.3
+    description: Security Options
+    checks:
+      - id: 2.3.1.1
+        description: Ensure 'Accounts: Block Microsoft accounts' is set to 'Users can't add or log on with Microsoft accounts' (Automated)
+        audittype: powershell
+        audit:
+          cmd:
+            DomainController: Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' noconnecteduser
+            Server: Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' noconnecteduser
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: "3"
+              set: true
+
+        remediation: >
+          To establish the recommended configuration via GP, set the following UI path to 'Users can't add or log on with Microsoft accounts':
+             Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Accounts: Block Microsoft accounts
+        scored: true

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -323,7 +323,7 @@ groups:
     description: Security Options
     checks:
       - id: 2.3.1.1
-        description: Ensure 'Accounts: Block Microsoft accounts' is set to 'Users can't add or log on with Microsoft accounts' (Automated)
+        description: Ensure 'Block Microsoft accounts' is set to 'Users can't add or log on with Microsoft accounts' (Automated)
         audittype: powershell
         audit:
           cmd:

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -300,7 +300,6 @@ groups:
           To establish the recommended configuration via GP, configure the following UI path:
              Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Access this computer from the network
         scored: true
-
       - id: 2.2.4
         description: Ensure 'Act as part of the operating system' is set to 'No One' (Automated)
         audittype: powershell

--- a/cfg/2.0.0/definitions.yaml
+++ b/cfg/2.0.0/definitions.yaml
@@ -352,10 +352,80 @@ groups:
                 op: eq
                 value: "3"
               set: true
-
         remediation: >
           To establish the recommended configuration via GP, set the following UI path to 'Users can't add or log on with Microsoft accounts':
              Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Accounts: Block Microsoft accounts
+        scored: true
+      - id: 2.3.1.2
+        description: Ensure 'Guest account status' is set to 'Disabled' (MS only) (Automated)
+        audittype: powershell
+        audit:
+          cmd:
+            Server: SecEdit /export /cfg seccfg /areas SecurityPolicy /quiet ; (Get-Content seccfg | Select-String -Pattern "EnableGuestAccount") -replace '^.*= |[*]' ; Remove-Item seccfg
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: "0"
+              set: true
+        remediation: >
+          To establish the recommended configuration via GP, set the following UI path to 'Disabled':
+             Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Accounts: Guest account status
+        scored: true
+      - id: 2.3.1.3
+        description: Ensure 'Limit local account use of blank passwords to console logon only' is set to 'Enabled' (Automated)
+        audittype: powershell
+        audit:
+          cmd:
+            DomainController: Get-ItemPropertyValue 'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa' LimitBlankPasswordUse
+            Server: Get-ItemPropertyValue 'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa' LimitBlankPasswordUse
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: eq
+                value: "1"
+              set: true
+        remediation: >
+          To establish the recommended configuration via GP, set the following UI path to 'Enabled':
+             Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Accounts: Limit local account use of blank passwords to console logon only
+        scored: true
+      - id: 2.3.1.4
+        description: Configure 'Rename administrator account' (Automated)
+        audittype: powershell
+        audit:
+          cmd:
+            DomainController: SecEdit /export /cfg seccfg /areas SecurityPolicy /quiet ; (Get-Content seccfg | Select-String -Pattern "NewAdministratorName") -replace '.*"([^"]+)".*','$1' ; Remove-Item seccfg
+            Server: SecEdit /export /cfg seccfg /areas SecurityPolicy /quiet ; (Get-Content seccfg | Select-String -Pattern "NewAdministratorName") -replace '.*"([^"]+)".*','$1' ; Remove-Item seccfg
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: noteq
+                value: "Administrator"
+              set: true
+        remediation: >
+          To establish the recommended configuration via GP, configure the following UI path:
+             Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Accounts: Rename administrator account
+        scored: true
+      - id: 2.3.1.5
+        description: Configure 'Rename guest account' (Automated)
+        audittype: powershell
+        audit:
+          cmd:
+            DomainController: SecEdit /export /cfg seccfg /areas SecurityPolicy /quiet ; (Get-Content seccfg | Select-String -Pattern "NewGuestName") -replace '.*"([^"]+)".*','$1' ; Remove-Item seccfg
+            Server: SecEdit /export /cfg seccfg /areas SecurityPolicy /quiet ; (Get-Content seccfg | Select-String -Pattern "NewGuestName") -replace '.*"([^"]+)".*','$1' ; Remove-Item seccfg
+        tests:
+          test_items:
+            - flag: ""
+              compare:
+                op: noteq
+                value: "Guest"
+              set: true
+        remediation: >
+          To establish the recommended configuration via GP, configure the following UI path:
+             Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Accounts: Rename guest account
         scored: true
 
   - id: 5


### PR DESCRIPTION
This PR adds policies for part 2.3 Security Options:
* 2.3.1.1 Ensure 'Accounts: Block Microsoft accounts' is set to 'Users can't add or log on with Microsoft accounts' (Automated)
* 2.3.1.2 Ensure 'Accounts: Guest account status' is set to 'Disabled' (MS only) (Automated)
* 2.3.1.3 Ensure 'Accounts: Limit local account use of blank passwords to console logon only' is set to 'Enabled' (Automated)
* 2.3.1.4 Configure 'Accounts: Rename administrator account' (Automated)
* 2.3.1.5 Configure 'Accounts: Rename guest account' (Automated)

![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/ffd480f9-bb85-4bda-892d-14f5ed789e21)
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/d4cd1f3c-34ab-4359-974c-c9ba35d4faaf)