### PR TITLE
feat: filter checks by server type

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -24,9 +24,9 @@ import (
 	"github.com/golang/glog"
 )
 
-func runControls(controls *check.Controls, checkList string) check.Summary {
+func runControls(controls *check.Controls, checkList string, serverType string) check.Summary {
 	var summary check.Summary
-
+	controls = filterByServerType(controls, serverType)
 	if checkList != "" {
 		ids := util.CleanIDs(checkList)
 		summary = controls.RunChecks(ids...)

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -100,11 +100,11 @@ func TestRunControls(t *testing.T) {
 	}
 
 	// Run all checks
-	sm := runControls(control, "")
+	sm := runControls(control, "", "Server")
 	assert.True(t, sm.Pass > 0)
 	// Run only specified checks
 	checkList := "1.1.1"
-	smt := runControls(control, checkList)
+	smt := runControls(control, checkList, "Server")
 	assert.True(t, smt.Pass == 1)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ var RootCmd = &cobra.Command{
 	Long:  `This tool runs the CIS Windows Benchmark (https://www.cisecurity.org/cis-benchmarks)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		b := commonCheck.NewBench()
-		ps, err := shell.NewPowerShell()
+		ps, serverType, err := shell.NewPowerShell()
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ var RootCmd = &cobra.Command{
 			glog.V(2).Info("Returning a PowerShell (Auditer) \n")
 			return ps
 		})
-		return runChecks(b)
+		return runChecks(b, serverType)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ var (
 	cfgDir            string
 	cfgFile           string
 	checkList         string
+	serverTypeParam   string
 	jsonFmt           bool
 	includeTestOutput bool
 	outputFile        string
@@ -63,6 +64,9 @@ var RootCmd = &cobra.Command{
 			glog.V(2).Info("Returning a PowerShell (Auditer) \n")
 			return ps
 		})
+		if len(serverTypeParam) > 0 {
+			serverType = serverTypeParam
+		}
 		return runChecks(b, serverType)
 	},
 }
@@ -110,6 +114,13 @@ func init() {
 		"c",
 		"",
 		`A comma-delimited list of checks to run as specified in CIS document. Example --check="1.1.1,1.1.2"`,
+	)
+	RootCmd.PersistentFlags().StringVarP(
+		&serverTypeParam,
+		"server-type",
+		"S",
+		"",
+		`Specify the type of server to run checks for. Example --server-type="Server" or --server-type="DomainController"`,
 	)
 
 	goflag.CommandLine.VisitAll(func(goflag *goflag.Flag) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,12 +58,12 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 		err = b.RegisterAuditType(shell.TypePowershell, func() interface{} {
-			if err != nil {
-				return nil
-			}
 			glog.V(2).Info("Returning a PowerShell (Auditer) \n")
 			return ps
 		})
+		if err != nil {
+			return err
+		}
 		if len(serverTypeParam) > 0 {
 			serverType = serverTypeParam
 		}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -53,7 +53,7 @@ func TestLoadConfig(t *testing.T) {
 
 func TestRunChecks(t *testing.T) {
 	b := getMockBench()
-	err := runChecks(b)
+	err := runChecks(b, "Server")
 	var write bytes.Buffer
 	outputWriter = &write
 	if err != nil {

--- a/shell/powershell.go
+++ b/shell/powershell.go
@@ -39,18 +39,18 @@ type shellStarter interface {
 
 type localShellStarter struct{}
 
-func NewPowerShell() (*PowerShell, error) {
+func NewPowerShell() (*PowerShell, string, error) {
 	p, err := constructShell(&localShellStarter{})
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	osType, err := p.performExec(osTypePowershellCommand)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get operating system type: %w", err)
+		return nil, "", fmt.Errorf("Failed to get operating system type: %w", err)
 	}
 	p.osType = osType
-	return p, nil
+	return p, p.osType, nil
 }
 
 func constructShell(c shellStarter) (*PowerShell, error) {


### PR DESCRIPTION
this change add the ability to filter checks by server type.
the purpose is to not run checks which do not match the require server type