### PR TITLE
fix: select cmd by type

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -46,11 +46,17 @@ func runChecks(b commonCheck.Bench) error {
 	}
 
 	summary := runControls(controls, checkList)
-	err = outputResults(controls, summary)
-	if err != nil {
-		return err
+
+	// `runControls` can detect some items without correct `cmd`, and the state will be set `SKIP`
+	// We should remove skipped controls, because there is no way to print them.
+	for _, group := range controls.Groups {
+		for i := len(group.Checks) - 1; i >= 0; i-- {
+			if group.Checks[i].State == commonCheck.SKIP {
+				group.Checks = append(group.Checks[:i], group.Checks[i+1:]...)
+			}
+		}
 	}
-	return nil
+	return outputResults(controls, summary)
 
 }
 

--- a/shell/powershell.go
+++ b/shell/powershell.go
@@ -15,6 +15,7 @@
 package shell
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -26,6 +27,8 @@ import (
 
 const TypePowershell = "powershell"
 const osTypePowershellCommand = `Get-ComputerInfo -Property "os*" | Select -ExpandProperty OsProductType`
+
+var errWrongOSType = errors.New("wrongOSType")
 
 type PowerShell struct {
 	Cmd    map[string]string
@@ -74,17 +77,16 @@ func (p *localShellStarter) startShell() (ps.Shell, error) {
 // It uses the aquasecurity/go-powershell package to interface with
 // the windows powershell to execute the command.
 func (p *PowerShell) Execute(customConfig ...interface{}) (result string, errMessage string, state check.State) {
-	if p.sh == nil {
-		errMessage = "PowerShell is not initialized!\n"
-		return "", errMessage, check.SKIP
-	}
 	if len(customConfig) > 0 {
 		p.updateCommand(customConfig[0])
 	}
 	stdout, err := p.executeCommand()
 	if err != nil {
 		errMessage = fmt.Sprintf("err: %v", err)
-		return "", errMessage, check.SKIP
+		if errors.Is(err, errWrongOSType) {
+			return "", errMessage, check.SKIP
+		}
+		return "", errMessage, check.FAIL
 	}
 
 	glog.V(2).Info(fmt.Sprintf("Powershell.Execute - stdout: %s\n", stdout))
@@ -122,9 +124,8 @@ func (p *PowerShell) executeCommand() (string, error) {
 func (p *PowerShell) commandForRuntimeOS() (string, error) {
 	cmd, found := p.Cmd[p.osType]
 	if !found {
-		return "", fmt.Errorf("Unable to find matching command for OS Type: %q", p.osType)
+		return "", errors.Join(errWrongOSType, fmt.Errorf("Unable to find matching command for OS Type: %q", p.osType))
 	}
-
 	return cmd, nil
 }
 

--- a/shell/powershell.go
+++ b/shell/powershell.go
@@ -76,7 +76,7 @@ func (p *localShellStarter) startShell() (ps.Shell, error) {
 func (p *PowerShell) Execute(customConfig ...interface{}) (result string, errMessage string, state check.State) {
 	if p.sh == nil {
 		errMessage = "PowerShell is not initialized!\n"
-		return "", errMessage, check.FAIL
+		return "", errMessage, check.SKIP
 	}
 	if len(customConfig) > 0 {
 		p.updateCommand(customConfig[0])
@@ -84,7 +84,7 @@ func (p *PowerShell) Execute(customConfig ...interface{}) (result string, errMes
 	stdout, err := p.executeCommand()
 	if err != nil {
 		errMessage = fmt.Sprintf("err: %v", err)
-		return "", errMessage, check.FAIL
+		return "", errMessage, check.SKIP
 	}
 
 	glog.V(2).Info(fmt.Sprintf("Powershell.Execute - stdout: %s\n", stdout))

--- a/shell/powershell_test.go
+++ b/shell/powershell_test.go
@@ -166,7 +166,7 @@ func TestExecute(t *testing.T) {
 	for _, testCase := range testCases {
 		result, em, st := testCase.ps.Execute()
 		if testCase.fail {
-			if st != check.FAIL {
+			if st != check.SKIP {
 				t.Errorf("Expected FAIL state but instead got %q", st)
 			} else if testCase.expectedErr != em {
 				t.Errorf("unexpected error: %q but instead got: %q", testCase.expectedErr, em)

--- a/shell/powershell_test.go
+++ b/shell/powershell_test.go
@@ -16,6 +16,7 @@ package shell
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aquasecurity/bench-common/check"
@@ -115,7 +116,7 @@ func TestExecute(t *testing.T) {
 				},
 			},
 			fail:        true,
-			expectedErr: `err: Unable to find matching command for OS Type: ""`,
+			expectedErr: `Unable to find matching command for OS Type: ""`,
 		},
 		{
 			ps: &PowerShell{
@@ -127,7 +128,7 @@ func TestExecute(t *testing.T) {
 				},
 			},
 			fail:        true,
-			expectedErr: `err: Unable to find matching command for OS Type: ""`,
+			expectedErr: `Unable to find matching command for OS Type: ""`,
 		},
 		{
 			ps: &PowerShell{
@@ -137,7 +138,7 @@ func TestExecute(t *testing.T) {
 				sh: &mockShell{},
 			},
 			fail:        true,
-			expectedErr: `err: Unable to find matching command for OS Type: ""`,
+			expectedErr: `Unable to find matching command for OS Type: ""`,
 		},
 		{
 			ps: &PowerShell{
@@ -168,7 +169,7 @@ func TestExecute(t *testing.T) {
 		if testCase.fail {
 			if st != check.SKIP {
 				t.Errorf("Expected FAIL state but instead got %q", st)
-			} else if testCase.expectedErr != em {
+			} else if !strings.Contains(em, testCase.expectedErr) {
 				t.Errorf("unexpected error: %q but instead got: %q", testCase.expectedErr, em)
 			}
 		} else if len(result) == 0 {


### PR DESCRIPTION
We should run cmd only for specific server type.
Run on `DomainController`:

Before:
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/9ee31905-288d-43f5-a7fd-1d5a79dafebd)
After:
![изображение](https://github.com/aquasecurity/windows-bench/assets/19297627/27c31255-e02b-4b8f-b29d-920a88fdc650)
fixes #65 