### PR TITLE
feat: detect some servers as `member servers`

### DIFF
--- a/shell/powershell.go
+++ b/shell/powershell.go
@@ -81,13 +81,12 @@ func NewPowerShell() (*PowerShell, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get operating system type: %w", err)
 	}
+	p.osType = osType
 	if osType == "Server" {
 		p.osType, err = getServerType(p)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get server type: %w", err)
 		}
-	} else {
-		p.osType = osType
 	}
 	return p, nil
 }

--- a/shell/powershell.go
+++ b/shell/powershell.go
@@ -56,11 +56,11 @@ type shellStarter interface {
 
 type localShellStarter struct{}
 
-func getServerType(ps *PowerShell) string {
+func getServerType(cmd *PowerShell) string {
 	// if any of these roles are enabled we'll detect it as 'MemberServer'
 	for _, role := range memberServerRoles {
 		// we can ignore error here, because `performExec` already logs it
-		res, _ := ps.performExec(fmt.Sprintf(roleStatePowershellCommand, role))
+		res, _ := cmd.performExec(fmt.Sprintf(roleStatePowershellCommand, role))
 		if res == "Enabled" {
 			return "MemberServer"
 		}


### PR DESCRIPTION
We should detect Member Servers that have the following Roles enabled:
o AD Certificate Services
o DHCP Server
o DNS Server
o File Server
o Hyper-V
o Network Policy and Access Services
o Print Server
o Remote Access Services
o Remote Desktop Services
o Web Server

For detecting these roles we use `Get-WindowsOptionalFeature` cmd that gets information about optional features in a Windows image.

## Mapping roles
Following Windows feature names are used for role mapping:
role | Windows Feature name
 --- | ---
 AD Certificate Services | ADCertificateServicesRole
DHCP Server | DNS-Server-Full-Role
DNS Server | DHCPServer
File Server | FileAndStorage-Services
Hyper-V |	Microsoft-Hyper-V
Network Policy and Access Services | NPAS-Role
Print Server | Printing-Server-Role
Remote Access Services | RemoteAccessServer
Remote Desktop Services | Remote-Desktop-Services
Web Server | IIS-WebServer

## Refs:
* [Get-WindowsOptionalFeature](https://learn.microsoft.com/en-us/powershell/module/dism/get-windowsoptionalfeature?view=windowsserver2022-ps)
* [Roles, Role Services, and Features included in Windows Server - Server Core](https://learn.microsoft.com/en-us/windows-server/administration/server-core/server-core-roles-and-services)
