### PR TITLE
feat: add a flag `config` for specific configuration files

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,7 +93,7 @@ func init() {
 	// Cobra supports Persistent Flags, which, if defined here,
 	// will be global for your application.
 
-	//	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.windows-bench.yaml)")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.windows-bench.yaml)")
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	RootCmd.PersistentFlags().BoolVar(&noResults, "noresults", false, "Disable printing of results section")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,7 +93,6 @@ func init() {
 	// Cobra supports Persistent Flags, which, if defined here,
 	// will be global for your application.
 
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.windows-bench.yaml)")
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	RootCmd.PersistentFlags().BoolVar(&noResults, "noresults", false, "Disable printing of results section")
@@ -101,6 +100,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&noRemediations, "noremediations", false, "Disable printing of remediations section")
 	RootCmd.Flags().StringVarP(&windowsCisVersion, "version", "", "2.0.0", "Specify windows cis version, automatically detected if unset")
 	RootCmd.Flags().StringVarP(&cfgDir, "config-dir", "D", "cfg", "directory to get benchmark definitions")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is empty, will be used 'cfg/<version>/definitions.yaml')")
 	RootCmd.PersistentFlags().BoolVar(&jsonFmt, "json", false, "Prints the results as JSON")
 	RootCmd.PersistentFlags().BoolVar(&includeTestOutput, "include-test-output", false, "Prints the test's output")
 	RootCmd.PersistentFlags().StringVar(&outputFile, "outputfile", "", "Writes the JSON results to output file")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -32,15 +32,19 @@ func runChecks(b commonCheck.Bench) error {
 	} else {
 		version = "2.0.0"
 	}
-	path, err := loadConfig(version)
-	if err != nil {
-		return err
+
+	if cfgFile == "" {
+		cfgFile, err = loadConfig(version)
+		if err != nil {
+			return err
+		}
 	}
-	glog.V(1).Info(fmt.Sprintf("Using benchmark file: %s\n", path))
+
+	glog.V(1).Info(fmt.Sprintf("Using benchmark file: %s\n", cfgFile))
 
 	// No Constraints for now
 	constraints := make([]string, 0)
-	controls, err := getControls(b, path, constraints)
+	controls, err := getControls(b, cfgFile, constraints)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds the ability to give a specific configuration file to windows-bench:

```
D:> windows-bench.exe --config D:\aqua\localdefs.yaml
```
fixes #80 